### PR TITLE
Fix the indicator refresh issues (#33, #40)

### DIFF
--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -498,7 +498,13 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
     private void updateSelection(int position) {
         for (int i = 0; i < tabCount; ++i) {
             View tv = tabsContainer.getChildAt(i);
-            tv.setSelected(i == position);
+            final boolean selected = i == position;
+            tv.setSelected(selected);
+            if (selected) {
+                selected(tv);
+            } else {
+                notSelected(tv);
+            }
         }
     }
 


### PR DESCRIPTION
The `TextView`s are not always refreshed when their selection states changes. This fixes it, and issues #33 and #40.