### PR TITLE
Specify type/packaging for support-v4 dependency

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 dependencies {
-    compile 'com.android.support:support-v4:21.0.2'
+    compile 'com.android.support:support-v4:21.0.2@aar'
 }
 
 android {


### PR DESCRIPTION
This will result in "<type>aar</type>" to be added to the support-v4 dependency declaration in library pom when pushing to Maven Central (or another maven repo). This fixes #37. Tested using gradle-mvn-push pushing to an artifactory server.

Signed-off-by: Matthias Stevens <matthias.stevens@gmail.com>