### PR TITLE
Fix: Side padding is ignored when paddingLeft and paddingRight are equal

### DIFF
--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -175,13 +175,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
         a.recycle();
 
         //In case we have the padding they must be equal so we take the biggest
-        if (paddingRight < paddingLeft) {
-            padding = paddingLeft;
-        }
-
-        if (paddingLeft < paddingRight) {
-            padding = paddingRight;
-        }
+        padding = Math.max(paddingLeft, paddingRight);
 
         // get custom attrs
         a = context.obtainStyledAttributes(attrs, R.styleable.PagerSlidingTabStrip);


### PR DESCRIPTION
If I configure the view like this...
```xml
<com.astuetz.PagerSlidingTabStrip
    android:id="@+id/tabs"
    android:layout_width="match_parent"
    android:layout_height="48dip"
    android:background="?attr/colorPrimary"
    android:paddingLeft="8dip"
    android:paddingRight="8dip"
/>
```

Side padding will be ignored...