### PR TITLE
Fixed the selected tab doesn't center after rotation

### DIFF
--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -266,11 +266,6 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
                 } else {
                     getViewTreeObserver().removeOnGlobalLayoutListener(this);
                 }
-
-                currentPosition = pager.getCurrentItem();
-                currentPositionOffset = 0f;
-                scrollToChild(currentPosition, 0);
-                updateSelection(currentPosition);
             }
         });
     }
@@ -404,6 +399,11 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
             }
             setPadding(padding, getPaddingTop(), padding, getPaddingBottom());
             if (scrollOffset == 0) scrollOffset = getWidth() / 2 - padding;
+
+            currentPosition = pager.getCurrentItem();
+            currentPositionOffset = 0f;
+            scrollToChild(currentPosition, 0);
+            updateSelection(currentPosition);
         }
     };
 


### PR DESCRIPTION
This is the fix of the issue when adding PagerSlidingTabStrip with pstsPaddingMiddle="true", then select any table and rotate the screen. The selected tab won't be center anymore.