### PR TITLE
Remove selected text color attribute

### DIFF
--- a/library/res/color-v21/default_tab_text.xml
+++ b/library/res/color-v21/default_tab_text.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="?android:textColorPrimary" android:state_selected="true" />
+  <item android:color="#50FFFFFF" />
+</selector>

--- a/library/res/color-v21/default_tab_text.xml
+++ b/library/res/color-v21/default_tab_text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:color="?android:textColorPrimary" android:state_selected="true" />
-  <item android:color="#50FFFFFF" />
+  <item android:color="#80FFFFFF" />
 </selector>

--- a/library/res/color/default_tab_text.xml
+++ b/library/res/color/default_tab_text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
   <item android:color="#FFFFFF" android:state_selected="true" />
-  <item android:color="#50FFFFFF" />
+  <item android:color="#80FFFFFF" />
 </selector>

--- a/library/res/color/default_tab_text.xml
+++ b/library/res/color/default_tab_text.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:color="#FFFFFF" android:state_selected="true" />
+  <item android:color="#50FFFFFF" />
+</selector>

--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -15,8 +15,6 @@
         <attr name="pstsShouldExpand" format="boolean" />
         <attr name="pstsTextAllCaps" format="boolean" />
         <attr name="pstsPaddingMiddle" format="boolean" />
-        <attr name="pstsTextColorSelected" format="color" />
-        <attr name="pstsTextAlpha" format="integer" />
         <attr name="pstsTextStyle">
             <flag name="normal" value="0x0" />
             <flag name="bold" value="0x1" />

--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -22,7 +22,6 @@ import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.database.DataSetObserver;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Paint.Style;
 import android.graphics.Typeface;
@@ -58,7 +57,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
     }
 
     // @formatter:off
-    private static final int[] ATTRS = new int[]{
+    private static final int[] ANDROID_ATTRS = new int[]{
             android.R.attr.textColorPrimary,
             android.R.attr.textSize,
             android.R.attr.textColor,
@@ -109,8 +108,6 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
     private int tabPadding = 12;
     private int tabTextSize = 14;
     private ColorStateList tabTextColor = null;
-    private ColorStateList tabTextColorSelected = null;
-    private int textAlpha = 150;
 
     private int paddingLeft = 0;
     private int paddingRight = 0;
@@ -157,14 +154,17 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
         tabTextSize = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, tabTextSize, dm);
 
         // get system attrs (android:textSize and android:textColor)
-        TypedArray a = context.obtainStyledAttributes(attrs, ATTRS);
+        TypedArray a = context.obtainStyledAttributes(attrs, ANDROID_ATTRS);
         tabTextSize = a.getDimensionPixelSize(TEXT_SIZE_INDEX, tabTextSize);
-        ColorStateList colorStateList = a.getColorStateList(TEXT_COLOR_INDEX);
+
+        if (a.hasValue(TEXT_COLOR_INDEX)) {
+            tabTextColor = a.getColorStateList(TEXT_COLOR_INDEX);
+        } else {
+            tabTextColor = getResources().getColorStateList(R.color.default_tab_text);
+        }
+
         int textPrimaryColor = a.getColor(TEXT_COLOR_PRIMARY, android.R.color.white);
 
-        underlineColor = textPrimaryColor;
-        dividerColor = textPrimaryColor;
-        indicatorColor = textPrimaryColor;
         int padding = a.getDimensionPixelSize(PADDING_INDEX, 0);
         paddingLeft = padding > 0 ? padding : a.getDimensionPixelSize(PADDING_LEFT_INDEX, 0);
         paddingRight = padding > 0 ? padding : a.getDimensionPixelSize(PADDING_RIGHT_INDEX, 0);
@@ -172,9 +172,9 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 
         // get custom attrs
         a = context.obtainStyledAttributes(attrs, R.styleable.PagerSlidingTabStrip);
-        indicatorColor = a.getColor(R.styleable.PagerSlidingTabStrip_pstsIndicatorColor, indicatorColor);
-        underlineColor = a.getColor(R.styleable.PagerSlidingTabStrip_pstsUnderlineColor, underlineColor);
-        dividerColor = a.getColor(R.styleable.PagerSlidingTabStrip_pstsDividerColor, dividerColor);
+        indicatorColor = a.getColor(R.styleable.PagerSlidingTabStrip_pstsIndicatorColor, textPrimaryColor);
+        underlineColor = a.getColor(R.styleable.PagerSlidingTabStrip_pstsUnderlineColor, textPrimaryColor);
+        dividerColor = a.getColor(R.styleable.PagerSlidingTabStrip_pstsDividerColor, textPrimaryColor);
         dividerWidth = a.getDimensionPixelSize(R.styleable.PagerSlidingTabStrip_pstsDividerWidth, dividerWidth);
         indicatorHeight = a.getDimensionPixelSize(R.styleable.PagerSlidingTabStrip_pstsIndicatorHeight, indicatorHeight);
         underlineHeight = a.getDimensionPixelSize(R.styleable.PagerSlidingTabStrip_pstsUnderlineHeight, underlineHeight);
@@ -187,16 +187,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
         isPaddingMiddle = a.getBoolean(R.styleable.PagerSlidingTabStrip_pstsPaddingMiddle, isPaddingMiddle);
         tabTypefaceStyle = a.getInt(R.styleable.PagerSlidingTabStrip_pstsTextStyle, Typeface.BOLD);
         tabTypefaceSelectedStyle = a.getInt(R.styleable.PagerSlidingTabStrip_pstsTextSelectedStyle, Typeface.BOLD);
-        tabTextColorSelected = a.getColorStateList(R.styleable.PagerSlidingTabStrip_pstsTextColorSelected);
-        textAlpha = a.getInt(R.styleable.PagerSlidingTabStrip_pstsTextAlpha, textAlpha);
         a.recycle();
-
-        tabTextColor = colorStateList == null ? getColorStateList(Color.argb(textAlpha,
-                Color.red(textPrimaryColor),
-                Color.green(textPrimaryColor),
-                Color.blue(textPrimaryColor))) : colorStateList;
-
-        tabTextColorSelected = tabTextColorSelected == null ? getColorStateList(textPrimaryColor) : tabTextColorSelected;
 
         setMarginBottomTabContainer();
 
@@ -278,8 +269,11 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
         TextView textView = (TextView) tabView.findViewById(R.id.tab_title);
         if (textView != null) {
             if (title != null) textView.setText(title);
-            ColorStateList color = pager.getCurrentItem() == position ? tabTextColorSelected : tabTextColor;
-            textView.setTextColor(color);
+
+            if (pager.getCurrentItem() == position) {
+                textView.setSelected(true);
+            }
+            textView.setTextColor(tabTextColor);
         }
 
         tabView.setFocusable(true);
@@ -506,7 +500,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
             TextView title = (TextView) tab.findViewById(R.id.tab_title);
             if (title != null) {
                 title.setTypeface(tabTypeface, tabTypefaceStyle);
-                title.setTextColor(tabTextColor);
+                title.setSelected(false);
             }
         }
     }
@@ -516,7 +510,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
             TextView title = (TextView) tab.findViewById(R.id.tab_title);
             if (title != null) {
                 title.setTypeface(tabTypeface, tabTypefaceSelectedStyle);
-                title.setTextColor(tabTextColorSelected);
+                title.setSelected(true);
             }
         }
     }


### PR DESCRIPTION
This removes the custom attribute for tab text color selected, replacing it with the standard behaviour of `android:textColor`.

---
Default case, with no `textColor` specified:

```xml
<com.astuetz.PagerSlidingTabStrip
        android:id="@+id/tabs"
        android:layout_width="match_parent"
        android:layout_height="?attr/actionBarSize"
        android:background="?attr/colorPrimary"
        app:pstsPaddingMiddle="true" />
```

![default_no_color_specified](https://cloud.githubusercontent.com/assets/2678555/6314815/6b87fd34-b9e5-11e4-8cdf-e4fd88290515.png)

---

Expected best case, with `textColor` specified with a custom color state list resource:

```xml
<com.astuetz.PagerSlidingTabStrip
        android:id="@+id/tabs"
        android:layout_width="match_parent"
        android:layout_height="?attr/actionBarSize"
        android:background="?attr/colorPrimary"
        android:textColor="@color/my_custom_tab_color_state_list"
        app:pstsPaddingMiddle="true" />
```

![color_state_list_specified](https://cloud.githubusercontent.com/assets/2678555/6314817/6b8b4b4c-b9e5-11e4-9c13-9bb92c191bdf.png)

---

Case with `textColor` specified with a color resource that's just a single color:

```xml
<com.astuetz.PagerSlidingTabStrip
        android:id="@+id/tabs"
        android:layout_width="match_parent"
        android:layout_height="?attr/actionBarSize"
        android:background="?attr/colorPrimary"
        android:textColor="@android:color/holo_green_light"
        app:pstsPaddingMiddle="true" />
```

![single_color_resource_specified](https://cloud.githubusercontent.com/assets/2678555/6314816/6b8a822a-b9e5-11e4-9855-3eec4b62da8e.png)

---

Case with `textColor` specified with a hex value:

```xml
<com.astuetz.PagerSlidingTabStrip
        android:id="@+id/tabs"
        android:layout_width="match_parent"
        android:layout_height="?attr/actionBarSize"
        android:background="?attr/colorPrimary"
        android:textColor="#ef23f1"
        app:pstsPaddingMiddle="true" />
```

![single_hex_color_specified](https://cloud.githubusercontent.com/assets/2678555/6314833/dc5e8474-b9e5-11e4-8158-53b1f0ce0d80.png)