### PR TITLE
Use Roboto Medium as the default weight and allow overriding it from the XML.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ Custom attr:
  * `pstsUnderlineHeight` Height of the full-width line on the bottom of the view.
  * `pstsTextAlpha` Set the text alpha transparency for non selected tabs. Range 0..255. 150 is it's default value. It **WON'T** be use if `textColor` is defined in the layout. If `textColor` is **NOT** defined, It will be apply to the non selected tabs.
  * `pstsTextColorSelected` Set selected tab text color. `textPrimaryColor` will be it's default color value.
- * `pstsTextStyle` Set the text style, default bold.
- * `pstsTextSelectedStyle` Set the text style of the selected tab, default bold.
+ * `pstsTextStyle` Set the text style, default normal on API 21, bold on older APIs.
+ * `pstsTextSelectedStyle` Set the text style of the selected tab, default normal on API 21, bold on older APIs.
+ * `pstsTextFontFamily` Set the font family name. Default `sans-serif-medium` on API 21, `sans-serif` on older APIs.
  * `pstsTextAllCaps` If true, all tab titles will be upper case, default true.
  * `pstsDividerColor` Color of the dividers between tabs. `textPrimaryColor` will be it's default color value.
  * `pstsDividerPadding` Top and bottom padding of the dividers.

--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -27,6 +27,7 @@
             <flag name="bold" value="0x1" />
             <flag name="italic" value="0x2" />
         </attr>
+        <attr name="pstsTextFontFamily" format="string" />
     </declare-styleable>
 
 </resources>

--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -120,6 +120,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
     private boolean isPaddingMiddle = false;
 
     private Typeface tabTypeface = null;
+    private String tabTypefaceName = "sans-serif";
     private int tabTypefaceStyle = Typeface.BOLD;
     private int tabTypefaceSelectedStyle = Typeface.BOLD;
 
@@ -185,11 +186,20 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
         scrollOffset = a.getDimensionPixelSize(R.styleable.PagerSlidingTabStrip_pstsScrollOffset, scrollOffset);
         textAllCaps = a.getBoolean(R.styleable.PagerSlidingTabStrip_pstsTextAllCaps, textAllCaps);
         isPaddingMiddle = a.getBoolean(R.styleable.PagerSlidingTabStrip_pstsPaddingMiddle, isPaddingMiddle);
-        tabTypefaceStyle = a.getInt(R.styleable.PagerSlidingTabStrip_pstsTextStyle, Typeface.BOLD);
-        tabTypefaceSelectedStyle = a.getInt(R.styleable.PagerSlidingTabStrip_pstsTextSelectedStyle, Typeface.BOLD);
+        tabTypefaceStyle = a.getInt(R.styleable.PagerSlidingTabStrip_pstsTextStyle, tabTypefaceStyle);
+        tabTypefaceSelectedStyle = a.getInt(R.styleable.PagerSlidingTabStrip_pstsTextSelectedStyle, tabTypefaceSelectedStyle);
         tabTextColorSelected = a.getColorStateList(R.styleable.PagerSlidingTabStrip_pstsTextColorSelected);
         textAlpha = a.getInt(R.styleable.PagerSlidingTabStrip_pstsTextAlpha, textAlpha);
+
+        String fontFamily = a.getString(R.styleable.PagerSlidingTabStrip_pstsTextFontFamily);
+
         a.recycle();
+
+        if (fontFamily != null) {
+            tabTypefaceName = fontFamily;
+        }
+
+        tabTypeface = Typeface.create(tabTypefaceName, tabTypefaceStyle);
 
         tabTextColor = colorStateList == null ? getColorStateList(Color.argb(textAlpha,
                 Color.red(textPrimaryColor),

--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -171,6 +171,13 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
         paddingRight = padding > 0 ? padding : a.getDimensionPixelSize(PADDING_RIGHT_INDEX, 0);
         a.recycle();
 
+        // Use Roboto Medium as the default typeface from API 21 onwards
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            tabTypefaceName = "sans-serif-medium";
+            tabTypefaceStyle = Typeface.NORMAL;
+            tabTypefaceSelectedStyle = Typeface.NORMAL;
+        }
+
         // get custom attrs
         a = context.obtainStyledAttributes(attrs, R.styleable.PagerSlidingTabStrip);
         indicatorColor = a.getColor(R.styleable.PagerSlidingTabStrip_pstsIndicatorColor, indicatorColor);


### PR DESCRIPTION
The Material design spec says that [Roboto Medium is the weight that should be used in tabs](http://www.google.com/design/spec/components/tabs.html#tabs-specs). On Android, it’s included as a system typeface from API 21 onwards.

This makes `sans-serif-medium` the default typeface on API 21 and up and adds a new attribute `app:pstsTextFontFamily` for overriding it from the XML. The attribute works exactly like `android:fontFamily` for TextViews.

Programmatic usage doesn’t change as `setTypeface` still overrides everything.

Let me know what you think!