### PR TITLE
Account for manually set padding when scrolling.

### DIFF
--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -359,8 +359,17 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
         if (isPaddingMiddle || paddingLeft > 0 || paddingRight > 0) {
+            int width;
+
+            if (isPaddingMiddle) {
+                width = getWidth();
+            } else {
+                // Account for manually set padding for offsetting tab start and end positions.
+                width = getWidth() - paddingLeft - paddingRight;
+            }
+
             //Make sure tabContainer is bigger than the HorizontalScrollView to be able to scroll
-            tabsContainer.setMinimumWidth(getWidth());
+            tabsContainer.setMinimumWidth(width);
             //Clipping padding to false to see the tabs while we pass them swiping
             setClipToPadding(false);
         }


### PR DESCRIPTION
Padding can be used to achieve better alignment. For example, it can be used to align the first tab to the title of a Toolbar [as in the Material design spec][1].

If android:paddingLeft or android:paddingRight are set in the XML, the tab container is too wide and will scroll even if all of the tabs fit.

This commit changes the view to account for its padding when calculating the container width. If app:pstsPaddingMiddle is true, the view will behave as before.

[1]: https://www.google.com/design/spec/components/tabs.html#tabs-types-of-tabs