### PR TITLE
Bug fixed when the indicator line, underline and dividers are drawn

### DIFF
--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -408,13 +408,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
         }
 
         final int height = getHeight();
-        // draw indicator line
-        rectPaint.setColor(indicatorColor);
-        Pair<Float, Float> lines = getIndicatorCoordinates();
-        canvas.drawRect(lines.first + paddingLeft, height - indicatorHeight, lines.second + paddingLeft, height, rectPaint);
-        // draw underline
-        rectPaint.setColor(underlineColor);
-        canvas.drawRect(paddingLeft, height - underlineHeight, tabsContainer.getWidth() + paddingRight, height, rectPaint);
+
         // draw divider
         if (dividerWidth != 0) {
             dividerPaint.setStrokeWidth(dividerWidth);
@@ -424,6 +418,15 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
                 canvas.drawLine(tab.getRight(), dividerPadding, tab.getRight(), height - dividerPadding, dividerPaint);
             }
         }
+
+        // draw underline
+        rectPaint.setColor(underlineColor);
+        canvas.drawRect(paddingLeft, height - underlineHeight, tabsContainer.getWidth() + paddingRight, height, rectPaint);
+
+        // draw indicator line
+        rectPaint.setColor(indicatorColor);
+        Pair<Float, Float> lines = getIndicatorCoordinates();
+        canvas.drawRect(lines.first + paddingLeft, height - indicatorHeight, lines.second + paddingLeft, height, rectPaint);
     }
 
     public void setOnTabReselectedListener(OnTabReselectedListener tabReselectedListener) {


### PR DESCRIPTION
Fix this issue: https://github.com/jpardogo/PagerSlidingTabStrip/issues/95

I think there is an error when the indicator line, underline and dividers are drawn.
The order in which draw is wrong.

Current order:
1. Indicator line
2. Underline
3. Dividers

The problems are:
- The dividers are drew above the underline.
- The underline is drew above the indicator line, and indicator is not visible.

I consider correct this order:
1. Dividers
2. Underline
3. Indicator line