### PR TITLE
Added more Alignment Options

### DIFF
--- a/library/res/values/attrs.xml
+++ b/library/res/values/attrs.xml
@@ -2,28 +2,36 @@
 <resources>
 
     <declare-styleable name="PagerSlidingTabStrip">
-        <attr name="pstsIndicatorColor" format="color" />
-        <attr name="pstsIndicatorHeight" format="dimension" />
-        <attr name="pstsUnderlineColor" format="color" />
-        <attr name="pstsUnderlineHeight" format="dimension" />
-        <attr name="pstsDividerColor" format="color" />
-        <attr name="pstsDividerWidth" format="dimension" />
-        <attr name="pstsDividerPadding" format="dimension" />
-        <attr name="pstsScrollOffset" format="dimension" />
-        <attr name="pstsShouldExpand" format="boolean" />
-        <attr name="pstsPaddingMiddle" format="boolean" />
-        <attr name="pstsTabPaddingLeftRight" format="dimension" />
-        <attr name="pstsTabBackground" format="reference" />
-        <attr name="pstsTabTextSize" format="dimension" />
-        <attr name="pstsTabTextColor" format="reference" />
+        <attr name="pstsIndicatorColor" format="color"/>
+        <attr name="pstsIndicatorHeight" format="dimension"/>
+        <attr name="pstsUnderlineColor" format="color"/>
+        <attr name="pstsUnderlineHeight" format="dimension"/>
+        <attr name="pstsDividerColor" format="color"/>
+        <attr name="pstsDividerWidth" format="dimension"/>
+        <attr name="pstsDividerPadding" format="dimension"/>
+        <attr name="pstsScrollOffset" format="dimension"/>
+        <attr name="pstsShouldExpand" format="boolean"/>
+        <!--<attr name="pstsPaddingMiddle" format="boolean"/>-->
+        <attr name="pstsTabPaddingLeftRight" format="dimension"/>
+        <attr name="pstsTabBackground" format="reference"/>
+        <attr name="pstsTabTextSize" format="dimension"/>
+        <attr name="pstsTabTextColor" format="reference"/>
         <attr name="pstsTabTextStyle" format="reference">
-            <flag name="normal" value="0x0" />
-            <flag name="bold" value="0x1" />
-            <flag name="italic" value="0x2" />
+            <flag name="normal" value="0x0"/>
+            <flag name="bold" value="0x1"/>
+            <flag name="italic" value="0x2"/>
         </attr>
-        <attr name="pstsTabTextAllCaps" format="boolean" />
-        <attr name="pstsTabTextAlpha" format="integer" />
-        <attr name="pstsTabTextFontFamily" format="string" />
+        <attr name="pstsTabTextAllCaps" format="boolean"/>
+        <attr name="pstsTabTextAlpha" format="integer"/>
+        <attr name="pstsTabTextFontFamily" format="string"/>
+        <attr name="pstsTabAlignment" format="enum">
+            <enum name="center_tabs" value="0"/>
+            <enum name="middle_scroll" value="1"/>
+            <enum name="left" value="2"/>
+            <enum name="center_fill" value="3"/>
+        </attr>
+
+
     </declare-styleable>
 
 </resources>

--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -97,8 +97,15 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 
     private boolean isExpandTabs = false;
     private boolean isCustomTabs;
-    private boolean isPaddingMiddle = false;
+  //  private boolean isPaddingMiddle = false;
     private boolean isTabTextAllCaps = true;
+
+    //sets the gravity of tabs to either start in middle or left hand side and fill screen
+    public static  int center =0;
+    public static  int centerScroll =1;
+    public static  int left =2;
+    public static int fillAndCenter = 3;
+    private int tabAlignment = left;
 
     private Typeface mTabTextTypeface = null;
     private int mTabTextTypefaceStyle = Typeface.BOLD;
@@ -170,7 +177,8 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
         mDividerPadding = a.getDimensionPixelSize(R.styleable.PagerSlidingTabStrip_pstsDividerPadding, mDividerPadding);
         isExpandTabs = a.getBoolean(R.styleable.PagerSlidingTabStrip_pstsShouldExpand, isExpandTabs);
         mScrollOffset = a.getDimensionPixelSize(R.styleable.PagerSlidingTabStrip_pstsScrollOffset, mScrollOffset);
-        isPaddingMiddle = a.getBoolean(R.styleable.PagerSlidingTabStrip_pstsPaddingMiddle, isPaddingMiddle);
+       // isPaddingMiddle = a.getBoolean(R.styleable.PagerSlidingTabStrip_pstsPaddingMiddle, isPaddingMiddle);
+        tabAlignment = a.getInt(R.styleable.PagerSlidingTabStrip_pstsTabAlignment, tabAlignment);
         mTabPadding = a.getDimensionPixelSize(R.styleable.PagerSlidingTabStrip_pstsTabPaddingLeftRight, mTabPadding);
         mTabBackgroundResId = a.getResourceId(R.styleable.PagerSlidingTabStrip_pstsTabBackground, mTabBackgroundResId);
         mTabTextSize = a.getDimensionPixelSize(R.styleable.PagerSlidingTabStrip_pstsTabTextSize, mTabTextSize);
@@ -330,9 +338,9 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
-        if (isPaddingMiddle || mPaddingLeft > 0 || mPaddingRight > 0) {
+        if (tabAlignment == centerScroll || tabAlignment == center || mPaddingLeft > 0 || mPaddingRight > 0) {
             int width;
-            if (isPaddingMiddle) {
+            if (tabAlignment == 0 || tabAlignment == 1 || tabAlignment == fillAndCenter) {
                 width = getWidth();
             } else {
                 // Account for manually set padding for offsetting tab start and end positions.
@@ -366,9 +374,49 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
                 removeGlobalLayoutListenerJB();
             }
 
-            if (isPaddingMiddle) {
+            if (tabAlignment == centerScroll) {
                 int mHalfWidthFirstTab = view.getWidth() / 2;
                 mPaddingLeft = mPaddingRight = getWidth() / 2 - mHalfWidthFirstTab;
+            }
+            if (tabAlignment == center) {
+                int mTabMArginWidth = view.getWidth() / mTabCount;
+
+                int sumOfTabWidth =0;
+               for(int x = 0; x <= mTabCount -1; x++){
+                 sumOfTabWidth = sumOfTabWidth + mTabsContainer.getChildAt(x).getWidth();
+
+               }
+                if(sumOfTabWidth < getWidth()){
+                    mPaddingLeft = mPaddingRight = (getWidth()-sumOfTabWidth)/2;
+                }else {
+                    mPaddingLeft = mPaddingRight = 0;
+                }
+                 }
+            if(tabAlignment == fillAndCenter){
+
+                mPaddingLeft = mPaddingRight = 0;
+                int sumOfTabWidth =0;
+                int tabLayoutMargin =0;
+                for(int x = 0; x <= mTabCount -1; x++){
+                    sumOfTabWidth = sumOfTabWidth + mTabsContainer.getChildAt(x).getWidth();
+                 //   Log.i("Ff" + getWidth(), "d=sum = " + sumOfTabWidth);
+                }
+
+               //whatch out in if for sums greater then get width
+                tabLayoutMargin= (getWidth() - sumOfTabWidth)/(mTabCount*2);
+                for(int x = 0; x <= mTabCount -1; x++){
+                   LinearLayout.LayoutParams layoutParams=  new LinearLayout.LayoutParams( LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+                    layoutParams.setMargins(tabLayoutMargin, getHeight()/4, tabLayoutMargin, getHeight()/4);
+                    mTabsContainer.getChildAt(x).setLayoutParams(layoutParams);
+
+                    //   Log.i("Ff" + getWidth(), "d=sum = " + sumOfTabWidth);
+                }
+
+
+
+
+
+
             }
 
             setPadding(mPaddingLeft, getPaddingTop(), mPaddingRight, getPaddingBottom());
@@ -743,6 +791,23 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 
     public void setTextColor(ColorStateList colorStateList) {
         this.mTabTextColor = colorStateList;
+        updateTabStyles();
+    }
+
+
+
+    public void setTabAlignment(int gravityType) {
+        switch (gravityType){
+            case 0:
+            case 1:
+            case 2:
+                default:
+                    break;
+
+        }
+
+
+
         updateTabStyles();
     }
 

--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -102,7 +102,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 
     //sets the gravity of tabs to either start in middle or left hand side and fill screen
     public static int center = 0;
-    public static int centerScroll = 1;
+    //center public static int centerScroll = 1;
     public static int left = 2;
     public static int fillAndCenter = 3;
     private int tabAlignment = left;
@@ -210,6 +210,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
         setTabsContainerParentViewPaddings();
 
         //Configure tab's container LayoutParams for either equal divided space or just wrap tabs
+
         mTabLayoutParams = isExpandTabs ?
                 new LinearLayout.LayoutParams(0, LayoutParams.MATCH_PARENT, 1.0f) :
                 new LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT);
@@ -339,7 +340,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
-        if (tabAlignment == centerScroll || tabAlignment == center || mPaddingLeft > 0 || mPaddingRight > 0) {
+        if (tabAlignment == center || tabAlignment == fillAndCenter || mPaddingLeft > 0 || mPaddingRight > 0) {
             int width;
             if (tabAlignment == 0 || tabAlignment == 1 || tabAlignment == fillAndCenter) {
                 width = getWidth();
@@ -364,6 +365,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
         super.onLayout(changed, l, t, r, b);
     }
 
+    int y = 0;
     private OnGlobalLayoutListener firstTabGlobalLayoutListener = new OnGlobalLayoutListener() {
 
         @Override
@@ -375,15 +377,16 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
                 removeGlobalLayoutListenerJB();
             }
 
-            if (tabAlignment == centerScroll) {
+           /* if (tabAlignment == centerScroll) {
                 int mHalfWidthFirstTab = view.getWidth() / 2;
                 mPaddingLeft = mPaddingRight = getWidth() / 2 - mHalfWidthFirstTab;
-            }
+            }*/
             if (tabAlignment == center) {
+                //Log.i("Called", "fit anddsdsdsd cent" + y++);
                 int sumOfTabWidth = 0;
                 for (int x = 0; x <= mTabCount - 1; x++) {
                     sumOfTabWidth = sumOfTabWidth + mTabsContainer.getChildAt(x).getWidth();
-
+                //    Log.i("Called", " cent" + x++);
                 }
                 if (sumOfTabWidth < getWidth()) {
                     mPaddingLeft = mPaddingRight = (getWidth() - sumOfTabWidth) / 2;
@@ -391,7 +394,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
                     mPaddingLeft = mPaddingRight = 0;
                 }
             }
-            if (tabAlignment == fillAndCenter) {
+                       if (tabAlignment == fillAndCenter) {
 
                 mPaddingLeft = mPaddingRight = 0;
                 int sumOfTabWidth = 0;
@@ -404,16 +407,19 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 
                 tabLayoutMargin = (getWidth() - sumOfTabWidth) / (mTabCount * 2);
                 //only will fit if the width is greater then the sum of the tab widths to avoid overlaps
-                if (getWidth() > sumOfTabWidth) {
+                if (getWidth() > sumOfTabWidth && y <= mTabCount) {
                     for (int x = 0; x <= mTabCount - 1; x++) {
+                        //Log.i("HEy", "" + y);
                         LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
                         layoutParams.setMargins(tabLayoutMargin, getHeight() / 4, tabLayoutMargin, getHeight() / 4);
+
                         mTabsContainer.getChildAt(x).setLayoutParams(layoutParams);
+                        //  mTabsContainer.setPadding(tabLayoutMargin, getHeight() / 4, tabLayoutMargin, getHeight() / 4);
+
+                        y++;
                     }
 
                 }
-
-
             }
 
             setPadding(mPaddingLeft, getPaddingTop(), mPaddingRight, getPaddingBottom());
@@ -554,6 +560,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
             if (tab_title != null) {
                 tab_title.setSelected(true);
             }
+
             if (isCustomTabs)
                 ((CustomTabProvider) mPager.getAdapter()).tabSelected(tab);
         }
@@ -723,6 +730,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 
     public void setUnderlineColor(int underlineColor) {
         this.mUnderlineColor = underlineColor;
+
         invalidate();
     }
 
@@ -797,16 +805,28 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 
     public void setTabAlignment(int Alignment) {
         switch (Alignment) {
-            case 0: tabAlignment =center;
-            case 1:tabAlignment = centerScroll;
-            case 2: tabAlignment =left;
-            case 3:tabAlignment = fillAndCenter;
-            default:tabAlignment =left;
+            case 0:
+                tabAlignment = center;
+                break;
+            //case 1:tabAlignment = centerScroll;
+            case 2:
+                tabAlignment = left;
+                break;
+            case 3:
+                tabAlignment = fillAndCenter;
+                break;
+            default:
+                tabAlignment = left;
                 break;
 
         }
+       /* public static int center = 0;
+        //center public static int centerScroll = 1;
+        public static int left = 2;
+        public static int fillAndCenter = 3;
+        private int tabAlignment = left;
+*/
 
-        updateTabStyles();
     }
 
     private ColorStateList createColorStateList(int color_state_default) {

--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -97,13 +97,13 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 
     private boolean isExpandTabs = false;
     private boolean isCustomTabs;
-  //  private boolean isPaddingMiddle = false;
+    //  private boolean isPaddingMiddle = false;
     private boolean isTabTextAllCaps = true;
 
     //sets the gravity of tabs to either start in middle or left hand side and fill screen
-    public static  int center =0;
-    public static  int centerScroll =1;
-    public static  int left =2;
+    public static int center = 0;
+    public static int centerScroll = 1;
+    public static int left = 2;
     public static int fillAndCenter = 3;
     private int tabAlignment = left;
 
@@ -177,7 +177,7 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
         mDividerPadding = a.getDimensionPixelSize(R.styleable.PagerSlidingTabStrip_pstsDividerPadding, mDividerPadding);
         isExpandTabs = a.getBoolean(R.styleable.PagerSlidingTabStrip_pstsShouldExpand, isExpandTabs);
         mScrollOffset = a.getDimensionPixelSize(R.styleable.PagerSlidingTabStrip_pstsScrollOffset, mScrollOffset);
-       // isPaddingMiddle = a.getBoolean(R.styleable.PagerSlidingTabStrip_pstsPaddingMiddle, isPaddingMiddle);
+        // isPaddingMiddle = a.getBoolean(R.styleable.PagerSlidingTabStrip_pstsPaddingMiddle, isPaddingMiddle);
         tabAlignment = a.getInt(R.styleable.PagerSlidingTabStrip_pstsTabAlignment, tabAlignment);
         mTabPadding = a.getDimensionPixelSize(R.styleable.PagerSlidingTabStrip_pstsTabPaddingLeftRight, mTabPadding);
         mTabBackgroundResId = a.getResourceId(R.styleable.PagerSlidingTabStrip_pstsTabBackground, mTabBackgroundResId);
@@ -254,7 +254,8 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
     private void addTab(final int position, CharSequence title, View tabView) {
         TextView textView = (TextView) tabView.findViewById(R.id.psts_tab_title);
         if (textView != null) {
-            if (title != null) textView.setText(title);
+            if (title != null)
+                textView.setText(title);
         }
 
         tabView.setFocusable(true);
@@ -379,48 +380,45 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
                 mPaddingLeft = mPaddingRight = getWidth() / 2 - mHalfWidthFirstTab;
             }
             if (tabAlignment == center) {
-                int mTabMArginWidth = view.getWidth() / mTabCount;
+                int sumOfTabWidth = 0;
+                for (int x = 0; x <= mTabCount - 1; x++) {
+                    sumOfTabWidth = sumOfTabWidth + mTabsContainer.getChildAt(x).getWidth();
 
-                int sumOfTabWidth =0;
-               for(int x = 0; x <= mTabCount -1; x++){
-                 sumOfTabWidth = sumOfTabWidth + mTabsContainer.getChildAt(x).getWidth();
-
-               }
-                if(sumOfTabWidth < getWidth()){
-                    mPaddingLeft = mPaddingRight = (getWidth()-sumOfTabWidth)/2;
-                }else {
+                }
+                if (sumOfTabWidth < getWidth()) {
+                    mPaddingLeft = mPaddingRight = (getWidth() - sumOfTabWidth) / 2;
+                } else {
                     mPaddingLeft = mPaddingRight = 0;
                 }
-                 }
-            if(tabAlignment == fillAndCenter){
+            }
+            if (tabAlignment == fillAndCenter) {
 
                 mPaddingLeft = mPaddingRight = 0;
-                int sumOfTabWidth =0;
-                int tabLayoutMargin =0;
-                for(int x = 0; x <= mTabCount -1; x++){
+                int sumOfTabWidth = 0;
+                int tabLayoutMargin = 0;
+                for (int x = 0; x <= mTabCount - 1; x++) {
                     sumOfTabWidth = sumOfTabWidth + mTabsContainer.getChildAt(x).getWidth();
-                 //   Log.i("Ff" + getWidth(), "d=sum = " + sumOfTabWidth);
-                }
 
-               //whatch out in if for sums greater then get width
-                tabLayoutMargin= (getWidth() - sumOfTabWidth)/(mTabCount*2);
-                for(int x = 0; x <= mTabCount -1; x++){
-                   LinearLayout.LayoutParams layoutParams=  new LinearLayout.LayoutParams( LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
-                    layoutParams.setMargins(tabLayoutMargin, getHeight()/4, tabLayoutMargin, getHeight()/4);
-                    mTabsContainer.getChildAt(x).setLayoutParams(layoutParams);
-
-                    //   Log.i("Ff" + getWidth(), "d=sum = " + sumOfTabWidth);
                 }
 
 
+                tabLayoutMargin = (getWidth() - sumOfTabWidth) / (mTabCount * 2);
+                //only will fit if the width is greater then the sum of the tab widths to avoid overlaps
+                if (getWidth() > sumOfTabWidth) {
+                    for (int x = 0; x <= mTabCount - 1; x++) {
+                        LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+                        layoutParams.setMargins(tabLayoutMargin, getHeight() / 4, tabLayoutMargin, getHeight() / 4);
+                        mTabsContainer.getChildAt(x).setLayoutParams(layoutParams);
+                    }
 
-
+                }
 
 
             }
 
             setPadding(mPaddingLeft, getPaddingTop(), mPaddingRight, getPaddingBottom());
-            if (mScrollOffset == 0) mScrollOffset = getWidth() / 2 - mPaddingLeft;
+            if (mScrollOffset == 0)
+                mScrollOffset = getWidth() / 2 - mPaddingLeft;
             mCurrentPosition = mPager.getCurrentItem();
             mCurrentPositionOffset = 0f;
             scrollToChild(mCurrentPosition, 0);
@@ -545,7 +543,8 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
             if (tab_title != null) {
                 tab_title.setSelected(false);
             }
-            if (isCustomTabs) ((CustomTabProvider) mPager.getAdapter()).tabUnselected(tab);
+            if (isCustomTabs)
+                ((CustomTabProvider) mPager.getAdapter()).tabUnselected(tab);
         }
     }
 
@@ -555,7 +554,8 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
             if (tab_title != null) {
                 tab_title.setSelected(true);
             }
-            if (isCustomTabs) ((CustomTabProvider) mPager.getAdapter()).tabSelected(tab);
+            if (isCustomTabs)
+                ((CustomTabProvider) mPager.getAdapter()).tabSelected(tab);
         }
     }
 
@@ -795,18 +795,16 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
     }
 
 
-
-    public void setTabAlignment(int gravityType) {
-        switch (gravityType){
-            case 0:
-            case 1:
-            case 2:
-                default:
-                    break;
+    public void setTabAlignment(int Alignment) {
+        switch (Alignment) {
+            case 0: tabAlignment =center;
+            case 1:tabAlignment = centerScroll;
+            case 2: tabAlignment =left;
+            case 3:tabAlignment = fillAndCenter;
+            default:tabAlignment =left;
+                break;
 
         }
-
-
 
         updateTabStyles();
     }

--- a/sample/res/layout/activity_main.xml
+++ b/sample/res/layout/activity_main.xml
@@ -12,7 +12,7 @@
         android:id="@+id/tabs"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        app:pstsTabAlignment="center_tabs"
+        app:pstsTabAlignment="center_fill"
         />
 
     <android.support.v4.view.ViewPager

--- a/sample/res/layout/activity_main.xml
+++ b/sample/res/layout/activity_main.xml
@@ -1,16 +1,19 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:fitsSystemWindows="true">
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:orientation="vertical"
+              android:fitsSystemWindows="true">
 
     <include layout="@layout/toolbar"/>
 
     <com.astuetz.PagerSlidingTabStrip
         android:id="@+id/tabs"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize" />
+        android:layout_height="?attr/actionBarSize"
+        app:pstsTabAlignment="center_tabs"
+        />
 
     <android.support.v4.view.ViewPager
         android:id="@+id/pager"

--- a/sample/src/com/astuetz/viewpager/extensions/sample/MainActivity.java
+++ b/sample/src/com/astuetz/viewpager/extensions/sample/MainActivity.java
@@ -70,7 +70,7 @@ public class MainActivity extends ActionBarActivity {
         final int pageMargin = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4, getResources()
                 .getDisplayMetrics());
         pager.setPageMargin(pageMargin);
-        pager.setCurrentItem(0);
+        pager.setCurrentItem(1);
         changeColor(getResources().getColor(R.color.green));
 
         tabs.setOnTabReselectedListener(new PagerSlidingTabStrip.OnTabReselectedListener() {
@@ -136,9 +136,8 @@ public class MainActivity extends ActionBarActivity {
 
     public class MyPagerAdapter extends FragmentPagerAdapter {
 
-        private final String[] TITLES = {"Categories", "Home", "Top Paid"};
-      //  , "Top Free", "Top Grossing", "Top New Paid",
-             ///   "Top New Free", "Trending"
+        private final String[] TITLES = {"Categories", "Home", "Top Paid", "Top Free", "Top Grossing", "Top New Paid",  "Top New Free", "Trending"};
+
         public MyPagerAdapter(FragmentManager fm) {
             super(fm);
         }

--- a/sample/src/com/astuetz/viewpager/extensions/sample/MainActivity.java
+++ b/sample/src/com/astuetz/viewpager/extensions/sample/MainActivity.java
@@ -70,7 +70,7 @@ public class MainActivity extends ActionBarActivity {
         final int pageMargin = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4, getResources()
                 .getDisplayMetrics());
         pager.setPageMargin(pageMargin);
-        pager.setCurrentItem(1);
+        pager.setCurrentItem(0);
         changeColor(getResources().getColor(R.color.green));
 
         tabs.setOnTabReselectedListener(new PagerSlidingTabStrip.OnTabReselectedListener() {
@@ -136,9 +136,9 @@ public class MainActivity extends ActionBarActivity {
 
     public class MyPagerAdapter extends FragmentPagerAdapter {
 
-        private final String[] TITLES = {"Categories", "Home", "Top Paid", "Top Free", "Top Grossing", "Top New Paid",
-                "Top New Free", "Trending"};
-
+        private final String[] TITLES = {"Categories", "Home", "Top Paid"};
+      //  , "Top Free", "Top Grossing", "Top New Paid",
+             ///   "Top New Free", "Trending"
         public MyPagerAdapter(FragmentManager fm) {
             super(fm);
         }

--- a/sample/src/com/astuetz/viewpager/extensions/sample/MainActivity.java
+++ b/sample/src/com/astuetz/viewpager/extensions/sample/MainActivity.java
@@ -67,6 +67,7 @@ public class MainActivity extends ActionBarActivity {
         adapter = new MyPagerAdapter(getSupportFragmentManager());
         pager.setAdapter(adapter);
         tabs.setViewPager(pager);
+        tabs.setAllCaps(false);
         final int pageMargin = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4, getResources()
                 .getDisplayMetrics());
         pager.setPageMargin(pageMargin);
@@ -79,6 +80,8 @@ public class MainActivity extends ActionBarActivity {
                 Toast.makeText(MainActivity.this, "Tab reselected: " + position, Toast.LENGTH_SHORT).show();
             }
         });
+      tabs.setTabAlignment(PagerSlidingTabStrip.fillAndCenter);
+
     }
 
     @Override
@@ -136,7 +139,9 @@ public class MainActivity extends ActionBarActivity {
 
     public class MyPagerAdapter extends FragmentPagerAdapter {
 
-        private final String[] TITLES = {"Categories", "Home", "Top Paid", "Top Free", "Top Grossing", "Top New Paid",  "Top New Free", "Trending"};
+        private final String[] TITLES = {"Categories", "Home", "Top Paid"};
+
+
 
         public MyPagerAdapter(FragmentManager fm) {
             super(fm);


### PR DESCRIPTION
I recently started to use this library for an app that I have been working on. However it did not seem to provide support for aligning the tabs, in a way that I desired. The isMiddle variable gave some control but was not flexible enough. Since then I have forked this repository and have made some modifications to the code. Instead of using the isMiddle boolean, I am using integers to allow for more then just 2 possible Alignments. While keeping the Alignments that were possible with isMiddle, I have also added an option to center and to fill and center. If it possible I would like to pull the PagerSliderTabStable class from the dev branch of the project to add these features.

Sorry if this is not enough or too much information, this is my first pull request on GitHub and I am not entirely sure of the in and outs.

https://github.com/nmac143/PagerSlidingTabStrip
![screenshot_20150622-144015] (https://cloud.githubusercontent.com/assets/6704857/8293976/cceefa20-1906-11e5-94fb-053ff3256f4a.png)
![screenshot_20150622-152342](https://cloud.githubusercontent.com/assets/6704857/8293977/d2019068-1906-11e5-8173-f3a037c42364.png)
