### PR TITLE
Fixed layout glitch when using isPaddingMiddle

### DIFF
--- a/library/src/com/astuetz/PagerSlidingTabStrip.java
+++ b/library/src/com/astuetz/PagerSlidingTabStrip.java
@@ -16,7 +16,6 @@
 
 package com.astuetz;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
@@ -38,7 +37,6 @@ import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.widget.HorizontalScrollView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -330,6 +328,18 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
 
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
+        if (isPaddingMiddle) {
+
+            View view = mTabsContainer.getChildAt(0);
+
+            if (view != null) {
+                int mHalfWidthFirstTab;
+                mHalfWidthFirstTab = view.getMeasuredWidth() / 2;
+                mPaddingLeft = mPaddingRight = getWidth() / 2 - mHalfWidthFirstTab;
+            }
+
+        }
+
         if (isPaddingMiddle || mPaddingLeft > 0 || mPaddingRight > 0) {
             int width;
             if (isPaddingMiddle) {
@@ -345,50 +355,17 @@ public class PagerSlidingTabStrip extends HorizontalScrollView {
             setClipToPadding(false);
         }
 
-        if (mTabsContainer.getChildCount() > 0) {
-            mTabsContainer
-                    .getChildAt(0)
-                    .getViewTreeObserver()
-                    .addOnGlobalLayoutListener(firstTabGlobalLayoutListener);
-        }
+
+        setPadding(mPaddingLeft, getPaddingTop(), mPaddingRight, getPaddingBottom());
+        if (mScrollOffset == 0) mScrollOffset = getWidth() / 2 - mPaddingLeft;
+        if (mPager != null) mCurrentPosition = mPager.getCurrentItem();
+        mCurrentPositionOffset = 0f;
+        scrollToChild(mCurrentPosition, 0);
+        updateSelection(mCurrentPosition);
+        invalidate();
 
         super.onLayout(changed, l, t, r, b);
     }
-
-    private OnGlobalLayoutListener firstTabGlobalLayoutListener = new OnGlobalLayoutListener() {
-
-        @Override
-        public void onGlobalLayout() {
-            View view = mTabsContainer.getChildAt(0);
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-                removeGlobalLayoutListenerPreJB();
-            } else {
-                removeGlobalLayoutListenerJB();
-            }
-
-            if (isPaddingMiddle) {
-                int mHalfWidthFirstTab = view.getWidth() / 2;
-                mPaddingLeft = mPaddingRight = getWidth() / 2 - mHalfWidthFirstTab;
-            }
-
-            setPadding(mPaddingLeft, getPaddingTop(), mPaddingRight, getPaddingBottom());
-            if (mScrollOffset == 0) mScrollOffset = getWidth() / 2 - mPaddingLeft;
-            mCurrentPosition = mPager.getCurrentItem();
-            mCurrentPositionOffset = 0f;
-            scrollToChild(mCurrentPosition, 0);
-            updateSelection(mCurrentPosition);
-        }
-
-        @SuppressWarnings("deprecation")
-        private void removeGlobalLayoutListenerPreJB() {
-            getViewTreeObserver().removeGlobalOnLayoutListener(this);
-        }
-
-        @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
-        private void removeGlobalLayoutListenerJB() {
-            getViewTreeObserver().removeOnGlobalLayoutListener(this);
-        }
-    };
 
     @Override
     protected void onDraw(Canvas canvas) {


### PR DESCRIPTION
This fixes a brief glitch that causes the paper tabs to start out left aligned for a couple milliseconds.

I believe this is because it has to do another layout pass to pick up the changes made with onGlobalLayoutListener, but when moved to onLayout it behaves properly.