### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For a working implementation of this project see the `sample/` folder.
 1. Include the following dependency in your `build.gradle` file.
 
 ```groovy
-compile 'com.jpardogo.materialtabstrip:library:1.1.1'
+implementation 'com.jpardogo.materialtabstrip:library:1.1.1'
 ```
 
 Or add the library as a project. I tried to send a pull request, but looks like the original developer doesn't maintain it anymore.


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.